### PR TITLE
fix(Facilities): add extra time to calculated walking distance

### DIFF
--- a/components/list-item.js
+++ b/components/list-item.js
@@ -29,7 +29,8 @@ const StyledIcon = styled('div')`
 const getWalkingDistance = (distanceMeters) => {
   if (!distanceMeters) return ''
 
-  const distanceMinutes = (distanceMeters / 1000) * 12.2 // average 12.2 min/km walking
+  let distanceMinutes = (distanceMeters / 1000) * 12.2 // average 12.2 min/km walking
+  distanceMinutes = distanceMinutes * 1.5 // add 50% to be closer to Google Maps results
   return distanceInWords(distanceMinutes)
 }
 


### PR DESCRIPTION
There was a discrepancy between the calculated walking distance shown on the Search page and the actual walking distance calculated by Google Maps.

Since we don't want to call the Google Maps API for every result on the Search page because that would make us exceed the amount of API calls, we are just adding 50% of extra time to it to get closer to the Google Maps results.