### PR TITLE
fix(facility): wrap welcome & service icons on small screens

### DIFF
--- a/pages/facilities/[id]/index.js
+++ b/pages/facilities/[id]/index.js
@@ -81,6 +81,12 @@ const DirectionsLink = styled(Link)`
   }
 `
 
+const IconsWraper = styled(Box)`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+`
+
 const getIcon = (icon, size) => {
   const icons = {
     male: Male,
@@ -191,14 +197,13 @@ const Facility = () => {
         <Grid item xs={12}>
           <SectionTitle>Welcomes</SectionTitle>
           <StyledPaper elevation={0} variant="outlined">
-            <Box display="flex">
+            <IconsWraper>
               {facility.welcomes?.map((item) => (
                 <Box
                   key={item.key}
                   display="flex"
                   flexDirection="column"
                   alignItems="center"
-                  paddingRight="18px"
                 >
                   {getIcon(item.key, 32)}
                   <Box fontSize="caption.fontSize" paddingTop="6px">
@@ -206,17 +211,17 @@ const Facility = () => {
                   </Box>
                 </Box>
               ))}
-            </Box>
+            </IconsWraper>
           </StyledPaper>
           <SectionTitle>Services</SectionTitle>
           <StyledPaper elevation={0} variant="outlined">
-            <Box display="flex">
+            <IconsWraper>
               {facility.services?.map((item) => (
-                <Box key={item.key} paddingRight="18px">
+                <Box key={item.key}>
                   {getIcon(item.key, 32)}
                 </Box>
               ))}
-            </Box>
+            </IconsWraper>
             <Box display="flex" flexDirection="column">
               {facility.services?.map(
                 (item) =>


### PR DESCRIPTION
Icons will wrap when the screens are too small to display all the icons.

<img width="502" alt="Screenshot 2024-11-11 at 12 55 07 PM" src="https://github.com/user-attachments/assets/a6924a1f-58a3-4fff-914f-45cf9f1acbf8">
